### PR TITLE
Fix incorrect nesting notations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ turret.js.map
 turret.css.map
 docs.js.map
 docs.css.map
+package-lock.json

--- a/turret/_mixins.css
+++ b/turret/_mixins.css
@@ -67,7 +67,7 @@
    */
 
   --text-hide: {
-    font: ~'0/0' a;
+    font: 0/0 a;
     color: transparent;
     text-shadow: none;
     background-color: transparent;

--- a/turret/base/print.css
+++ b/turret/base/print.css
@@ -76,8 +76,8 @@
   table {
     border-collapse: collapse !important;
 
-    td,
-    th {
+    & td,
+    & th {
       background-color: var(--white) !important;
     }
   }

--- a/turret/element/table.css
+++ b/turret/element/table.css
@@ -76,15 +76,15 @@ td {
       }
 
       & tr:first-child {
-        > th,
-        > td {
+        & > th,
+        & > td {
           border-top: none;
         }
       }
 
       & tr:last-child {
-        > th,
-        > td {
+        & > th,
+        & > td {
           border-bottom: none;
         }
       }

--- a/turret/typography/headings.css
+++ b/turret/typography/headings.css
@@ -18,7 +18,7 @@ h6,
   text-transform: var(--headings-text-transform);
   letter-spacing: var(--headings-letter-spacing);
 
-  small {
+  & small {
     font-family: var(--headings-small-font-family);
     font-weight: var(--headings-small-font-weight);
     font-size: var(--headings-small-size);


### PR DESCRIPTION
When I tried using turretcss with purifycss I stumbled upon 3 parsing errors due to "incorrect" nesting (based on [this](http://tabatkins.github.io/specs/css-nesting/) draft of the CSS Nesting spec).

While I was at it, I also fixed a value error which was already mentioned in the pull request #18 (I was worried it might cause additional issues with purifycss).

This is my first pull request in a **long** time, so I'd appreciate the feedback if I did something the wrong way 🎉!