### PR TITLE
Fix FUNDING.yml GitHub line

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-# github: [scottdejonge] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [scottdejonge] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 # patreon: # Replace with a single Patreon username
 # open_collective: # Replace with a single Open Collective username
 # ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
I suspect the GitHub line was left commented out unintentionally. As a result, the Sponsor button is shown on the repo, however, using it results in GitHub giving back an error: 

```
The FUNDING.yml file does not currently contain valid funding links.
Learn more about formatting FUNDING.yml.
```